### PR TITLE
Create and Upate kqls

### DIFF
--- a/Chart/0.csl
+++ b/Chart/0.csl
@@ -1,10 +1,7 @@
 //Chart//LA//
 SecurityIncident
 | extend KST_Time = datetime_utc_to_local(CreatedTime, 'Asia/Seoul') // UTC -> KST 변환
-| where KST_Time between (ago(7d) .. now())
-| extend Tactics = todynamic(AdditionalData.tactics)
-| extend Owner = tostring(Owner.assignedTo) 
-| extend Product = tostring(parse_json(tostring(AdditionalData.alertProductNames))[0]) 
+| where KST_Time between (startofday(ago(7d)) .. endofday(ago(1d)))
 | summarize High = dcountif(IncidentNumber, Severity == 'High'),
             Medium = dcountif(IncidentNumber, Severity == 'Medium'),
             Low = dcountif(IncidentNumber, Severity == 'Low')

--- a/Table/23.csl
+++ b/Table/23.csl
@@ -1,7 +1,8 @@
 //Table//LA//
 SecurityIncident
-| extend localTime = datetime_utc_to_local(FirstActivityTime, 'Asia/Seoul') // UTC -> KST 변환
-| where localTime between (datetime_utc_to_local(ago(7d), 'Asia/Seoul') .. datetime_utc_to_local(now(), 'Asia/Seoul'))
+| extend KST_Time = datetime_utc_to_local(CreatedTime, 'Asia/Seoul') // UTC -> KST 변환
+| where KST_Time between (startofday(ago(7d)) .. endofday(ago(1d)))
+| where Severity != "Informational"
 | extend Description = iif(isnull(Description), "", Description)
 | distinct Title, Description
 | order by Title asc

--- a/Table/5.csl
+++ b/Table/5.csl
@@ -13,7 +13,7 @@ SecureScores
 | extend Day = startofday(TimeGenerated) 
 | summarize arg_max(TimeGenerated, *) by Day, Scope 
 | summarize arg_max(Day, *) by Scope 
-| join kind = fullouter( 
+| join kind = inner( 
     SecureScores 
     | extend Scope = iff(AssessedResourceId has "securityConnectors", split(AssessedResourceId, "/providers/Microsoft.Security/secureScores/")[0], tostring(SecureScoresSubscriptionId))
     | extend Day = startofday(TimeGenerated) 
@@ -45,3 +45,4 @@ SecureScores
 //| extend DiffMonth = tostring(((PercentageScore - OldMonthScore) / OldMonthScore) * 100) 
 //| extend DiffMonth = iff(isempty(DiffMonth), "", DiffMonth) 
 | project Scope, CurrentScore = round(PercentageScore * 100, 0),todouble(DiffSevenDays)
+| where isnotempty(Scope)


### PR DESCRIPTION
- Table/4.csl : Agentless 기반으로 탐지된 보안 경고가 쿼리될 수 있도록 조건 추가
- Table/5.csl : 최근 일주일간의 구독 보안 점수만 나오도록 수정
- Table/23.csl : Informational 인시던트 제외
- Chart/0.csl : where 시간 조건절 수정, 불필요한 구문 제거